### PR TITLE
Fixed trim function to actually work

### DIFF
--- a/gb.pl
+++ b/gb.pl
@@ -95,7 +95,7 @@ sub logtext {
 
 # Trims whitespace. Why a text parser language doesn't have this is beyond me.
 sub trim {
-	my $temp=$_;
+	my $temp=shift;
 	$temp=~s/^\s+|\s+$//g;
 	return $temp;
 }


### PR DESCRIPTION
I have no idea why it was $_ instead of shift, but it should work now.
