### PR TITLE
Added manual aliases functionality

### DIFF
--- a/gummyfun/aliases
+++ b/gummyfun/aliases
@@ -1,0 +1,1 @@
+ForwardBias ForwardBias|work ForwardBias|ManualMaster


### PR DESCRIPTION
It's still best to use the current user's nickname since it's currently merged with the automatic AKA list, but this one allowns for n-way mapping since it can't be confused by people stealing nicks.