### PR TITLE
Modified %peep subs to remove used peeps from the list

### DIFF
--- a/gb.pl
+++ b/gb.pl
@@ -642,12 +642,17 @@ sub dofunsubs {
 
 		# if there isn't anyone else, then add us just so the list isn't empty.
 		if (scalar @nicks < 1) {
-			push @nicks, $server->{nick};
+			push @nicks, "Nopony";
 		}
-
 		my $mynum=rand(scalar(@nicks));
-		while ($text =~ s/(^|[^\\])%peep/$1$nicks[$mynum]/) {
+		my $peepnick=splice(@nicks,$mynum,1);
+
+		while ($text =~ s/(^|[^\\])%peep/$1$peepnick/) {
+			if (scalar @nicks < 1) {
+				push @nicks, "Nopony";
+			}
 			$mynum=rand(scalar(@nicks));
+			$peepnick=splice(@nicks,$mynum,1);
 		};
 	}
 


### PR DESCRIPTION
This was chosen as a compromise to the issues of spamming people
who weren't in the channel and avoiding duplicates. It has a bit
of code duplication, but nothing too major.